### PR TITLE
添加 Markstream 到 Chatbot UI

### DIFF
--- a/awesome-dev-ai.md
+++ b/awesome-dev-ai.md
@@ -290,6 +290,7 @@ _Development Framework._
 - Chatbot UI
   - [assistant-ui](https://github.com/Yonom/assistant-ui)
     - [Tool UI](https://www.tool-ui.com/)
+  - [Markstream](https://github.com/Simon-He95/markstream-vue) - 面向 AI 对话流式输出的 Markdown 渲染器，支持 Vue、React、Svelte、Angular，内置 Mermaid、KaTeX 与代码高亮。
   - [Vercel AI SDK - AI Elements](https://ai-sdk.dev/elements)
   - [nlux](https://docs.nlkit.com/nlux)
 


### PR DESCRIPTION
## 说明

在「开发框架 → Chatbot UI」中补充 [Markstream](https://github.com/Simon-He95/markstream-vue)。

Markstream 是面向 AI 对话流式输出的开源 Markdown 渲染器，支持 Vue/Nuxt、React/Next.js、Svelte、Angular 和 Vue 2，并内置 Mermaid、KaTeX、代码高亮和安全 HTML 支持。

- 文档：https://markstream.simonhe.me/
- 在线演示：https://markstream-vue.simonhe.me/

提交前已检索仓库，未发现已有 Markstream 条目。感谢维护这份资源清单！